### PR TITLE
need to also escape '<' in attribute values

### DIFF
--- a/lib/undies/element.rb
+++ b/lib/undies/element.rb
@@ -16,7 +16,7 @@ module Undies
         html + if k_v.last.kind_of?(::Hash)
           hash_attrs(k_v.last, k_v.first)
         else
-          " #{k_v.first}=\"#{k_v.last.gsub('"', '&quot;')}\""
+          " #{k_v.first}=\"#{k_v.last.gsub('"', '&quot;').gsub('<', '&lt;')}\""
         end
       end
     end

--- a/test/element_test.rb
+++ b/test/element_test.rb
@@ -51,6 +51,11 @@ class Undies::Element
       assert_includes 'escaped="&quot;this&quot; is double-quoted"', attrs
     end
 
+    should "escape '<' in attr values" do
+      attrs = Undies::Element.hash_attrs('escaped' => 'not < escaped')
+      assert_includes 'escaped="not &lt; escaped"', attrs
+    end
+
     should "convert a nested hash to element attrs" do
       attrs = Undies::Element.hash_attrs({
         :class => "testing", :id => "test_2",


### PR DESCRIPTION
- "In character data and attribute values, the character information items "<" and "&" are represented by "&lt;" and "&amp;" respectively."
- http://www.w3.org/TR/2000/WD-xml-c14n-20000119.html#charescaping
